### PR TITLE
Issues moved from Jira to Github

### DIFF
--- a/permissions/plugin-publish-over-ssh.yml
+++ b/permissions/plugin-publish-over-ssh.yml
@@ -1,8 +1,8 @@
 ---
 name: "publish-over-ssh"
-github: "jenkinsci/publish-over-ssh-plugin"
+github: &GH "jenkinsci/publish-over-ssh-plugin"
 issues:
-- jira: '15792' # publish-over-ssh-plugin
+- github: *GH
 paths:
 - "org/jenkins-ci/plugins/publish-over-ssh"
 - "org/jvnet/hudson/plugins/publish-over-ssh"


### PR DESCRIPTION
# Description

[publish-over-ssh-plugin ](https://github.com/jenkinsci/publish-over-ssh-plugin) now uses Github for issues

### Always

- [X] Add link to plugin/component Git repository in description above

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
