### PR TITLE
Enable CD

### DIFF
--- a/permissions/plugin-publish-over-ssh.yml
+++ b/permissions/plugin-publish-over-ssh.yml
@@ -6,6 +6,8 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/publish-over-ssh"
   - "org/jvnet/hudson/plugins/publish-over-ssh"
+cd:
+  enabled: true
 developers:
   - "gmcdonald"
   - "olamy"


### PR DESCRIPTION
Enable Continuous Delivery for the publish-over-ssh plugin

Related PR : https://github.com/jenkinsci/publish-over-ssh-plugin/pull/363